### PR TITLE
Full DNS support for service names containing dots ('.')

### DIFF
--- a/command/agent/dns.go
+++ b/command/agent/dns.go
@@ -343,10 +343,9 @@ PARSE:
 
 			// Support "." in the label, re-join all the parts
 			tag := ""
-			svc := ""
+			svc := labels[n-2]
 			if n >= 3 {
 				tag = strings.Join(labels[:n-2], ".")
-				svc = labels[n-2]
 				for i, s := range labels {
 					if "tags" == s {
 						// [tag.[tag.[...]]].tags.com.acme.orders.service.consul


### PR DESCRIPTION
Using the DNS interface, you cannot search services whose names contain dots (e.g. 'com.acme.sales.service.consul'), since the code will interpret 'sales' as the service name and 'com', 'acme' as tags the service returned must contain.
This commit proposes an extended FQDN syntax for service searches: '[tag.[tag.[...]]]]tags.svc.name.with.dots.service.consul'. The code behaves identically to latest main branch code if 'tags' is not present in the FQDN, but if it is it parses the FQDN according to the extended FQDN syntax.

'make test' throws a lot of errors in my machine, but none seems related to this change.